### PR TITLE
Add !important to background-color

### DIFF
--- a/src/DebugBar/Resources/vendor/highlightjs/styles/github.css
+++ b/src/DebugBar/Resources/vendor/highlightjs/styles/github.css
@@ -7,7 +7,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 div.phpdebugbar .hljs {
   display: block; padding: 0.5em;
   color: #333;
-  background: #f8f8f8
+  background: #f8f8f8 !important;
 }
 
 div.phpdebugbar .hljs-comment,


### PR DESCRIPTION
Forces light background-color to pre tag.